### PR TITLE
add option to enable security group IDs for source restriction

### DIFF
--- a/api/securitypolicy/securitypolicy_types_functions.go
+++ b/api/securitypolicy/securitypolicy_types_functions.go
@@ -146,12 +146,18 @@ func (sp *SecurityPolicy) AddOutboundFirewallAction(name, action, direction stri
 }
 
 // AddInboundFirewallAction adds outbound firewall action rule into security policy.
-func (sp *SecurityPolicy) AddInboundFirewallAction(name, action, direction string, applicationObjectIDs []string) error {
+func (sp *SecurityPolicy) AddInboundFirewallAction(name, action, direction string, secGroupObjectIDs, applicationObjectIDs []string) error {
 	if action != "allow" && action != "block" {
 		return errors.New("Action can be only 'allow' or 'block'")
 	}
 	if direction != "inbound" {
 		return errors.New("Direction can only be 'inbound'")
+	}
+
+	var secondarySecurityGroupList = []SecurityGroup{}
+	for _, secGroupID := range secGroupObjectIDs {
+		securityGroup := SecurityGroup{ObjectID: secGroupID}
+		secondarySecurityGroupList = append(secondarySecurityGroupList, securityGroup)
 	}
 
 	var secondaryApplicationsList = &Applications{}
@@ -175,6 +181,7 @@ func (sp *SecurityPolicy) AddInboundFirewallAction(name, action, direction strin
 		Category:     "firewall",
 		Direction:    direction,
 		IsEnabled:    true,
+		SecondarySecurityGroup: secondarySecurityGroupList,
 		Applications: secondaryApplicationsList,
 	}
 


### PR DESCRIPTION

Addition of security group ID to Inbound Firewall Action.
Which will provide the facility to apply restrictions by source nodes in a specific security group.